### PR TITLE
Fix XmlUtils.GetXmlDecimal()

### DIFF
--- a/Westwind.Utilities.Test/XmlUtilsTest.cs
+++ b/Westwind.Utilities.Test/XmlUtilsTest.cs
@@ -43,6 +43,7 @@ namespace Westwind.Utilities.Tests
 	<name>Bill Bunsen</name>
 	<count>32</count>
 	<price>122.22</price>
+	<discount>1,30</discount>
 	<keyValue>value2</keyValue>
 	<isActive>true</isActive>
 	<attributeNode type=""data"" count=""21""  isLive=""true"" />
@@ -65,6 +66,9 @@ namespace Westwind.Utilities.Tests
 
 			decimal price = XmlUtils.GetXmlDecimal(node, "price");
 			Assert.AreEqual(122.22M, price);
+
+			decimal discount = XmlUtils.GetXmlDecimal(node, "discount");
+			Assert.AreEqual(130M, discount);
 
 			bool isActive = XmlUtils.GetXmlBool(node, "isActive");
 			Assert.IsTrue(isActive);

--- a/Westwind.Utilities/Utilities/XmlUtils.cs
+++ b/Westwind.Utilities/Utilities/XmlUtils.cs
@@ -32,6 +32,7 @@
 #endregion
 
 using System;
+using System.Globalization;
 using System.Xml;
 using Westwind.Utilities.Properties;
 
@@ -122,7 +123,7 @@ namespace Westwind.Utilities
 			    return 0;
 
 		    decimal result = 0;
-		    decimal.TryParse(val, out result);
+		    decimal.TryParse(val, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
 
 		    return result;
 	    }


### PR DESCRIPTION
Parse decimals in a culture invariant way, forcing "." to be the decimal
separator and "," to be the "thousands separator".
This prevents GetXmlDecimal() from returning giberish on systems
configured with a locale that use "," as the decimal separator.