### PR TITLE
Update HtmlUtils.cs to fix XSS Attack , it's different between Westwind.Utilities.HtmlEncode and System.Web.HttpUtility.HtmlEncode on `'`.

### DIFF
--- a/Westwind.Utilities/Utilities/HtmlUtils.cs
+++ b/Westwind.Utilities/Utilities/HtmlUtils.cs
@@ -122,6 +122,9 @@ namespace Westwind.Utilities
                     case '&':
                         sb.Append("&amp;");
                         break;
+                    case '\'':
+                        sb.Append("&#39;");
+                        break;				
                     default:
                         if (text[i] > 159)
                         {


### PR DESCRIPTION
it's different between Westwind.Utilities.HtmlEncode and System.Web.HttpUtility.HtmlEncode  on `'`.

```C#
	var HttpUtilityEncodeResult = System.Web.HttpUtility.HtmlEncode("alert('XSS Attack')"); //"alert(&#39;XSS Attack&#39;)"
	var WestwindEncodeResult = Westwind.Utilities.HtmlUtils.HtmlEncode("alert('XSS Attack')"); //"alert('XSS Attack')"
```
![](https://i.imgur.com/vuCWruw.png)