### PR TITLE
Microsoft data sql client

### DIFF
--- a/Westwind.Utilities/Configuration/AppConfiguration.cs
+++ b/Westwind.Utilities/Configuration/AppConfiguration.cs
@@ -38,8 +38,12 @@ using System.Configuration;
 using System.Reflection;
 using System.Xml;
 using System.Globalization;
-
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
+
 using System.Xml.Serialization;
 using System.Diagnostics;
 

--- a/Westwind.Utilities/Configuration/Providers/SqlServerConfigurationProvider.cs
+++ b/Westwind.Utilities/Configuration/Providers/SqlServerConfigurationProvider.cs
@@ -35,7 +35,11 @@
 // TODO: Doesn't work due to missing SqlDbClientFactories which should be added later
 
 
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using Westwind.Utilities.Data;
 using System.Data.Common;
 using System;

--- a/Westwind.Utilities/Data/ConnectionStringInfo.cs
+++ b/Westwind.Utilities/Data/ConnectionStringInfo.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Configuration;
 using System.Data.Common;
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using Westwind.Utilities.Properties;
 
 namespace Westwind.Utilities.Data

--- a/Westwind.Utilities/Data/DAL/DataAccessBase.cs
+++ b/Westwind.Utilities/Data/DAL/DataAccessBase.cs
@@ -38,7 +38,11 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;

--- a/Westwind.Utilities/Data/DAL/SqlDataAccess.cs
+++ b/Westwind.Utilities/Data/DAL/SqlDataAccess.cs
@@ -35,7 +35,11 @@
 
 using System;
 using System.Data.Common;
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 
 namespace Westwind.Utilities.Data
 {

--- a/Westwind.Utilities/Logging/SqlLogAdapter.cs
+++ b/Westwind.Utilities/Logging/SqlLogAdapter.cs
@@ -38,7 +38,11 @@ using System.Drawing;
 using System.Data.Common;
 using System.Collections.Generic;
 using System.Reflection;
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 
 namespace Westwind.Utilities.Logging
 {

--- a/Westwind.Utilities/Utilities/DataUtils.cs
+++ b/Westwind.Utilities/Utilities/DataUtils.cs
@@ -34,7 +34,11 @@
 using System;
 using System.Data;
 using System.Linq;
+#if NETSTANDARD2_0
+using Microsoft.Data.SqlClient;
+#else
 using System.Data.SqlClient;
+#endif
 using System.Reflection;
 using System.Collections.Generic;
 using System.Text;

--- a/Westwind.Utilities/Westwind.Utilities.csproj
+++ b/Westwind.Utilities/Westwind.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0;net40</TargetFrameworks>
-    <Version>3.0.37</Version>
+    <Version>3.0.27</Version>
     <Authors>Rick Strahl</Authors>
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Language>en-US</Language>
@@ -55,7 +55,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -69,6 +71,9 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
+    <!--<PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>1.1.2</Version>
+    </PackageReference>-->
   </ItemGroup>
 
 
@@ -102,4 +107,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+
+  
 </Project>

--- a/Westwind.Utilities/Westwind.Utilities.csproj
+++ b/Westwind.Utilities/Westwind.Utilities.csproj
@@ -71,9 +71,6 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
-    <!--<PackageReference Include="Microsoft.Data.SqlClient">
-      <Version>1.1.2</Version>
-    </PackageReference>-->
   </ItemGroup>
 
 


### PR DESCRIPTION
Addresses #15 
Added Reference to Microsoft.Data.SqlClient.
Added NETSTANDARD2_0 directives to using statements to target Microsoft.Data.SqlClient, vs System.Data.SqlClient.  May want to review this and target additional frameworks.
I did not see anything that would create the necessary databases for the Integration tests so I was unable to run a full suite.