### PR TITLE
Do not crash when ApplicationPool User has ReadOnly access

### DIFF
--- a/Westwind.Utilities/Configuration/AppConfiguration.cs
+++ b/Westwind.Utilities/Configuration/AppConfiguration.cs
@@ -160,8 +160,8 @@ namespace Westwind.Utilities.Configuration
                 provider = OnCreateDefaultProvider(sectionName, configData);
 
             Provider = provider;
-            if (!Provider.Read(this))
-                throw new InvalidOperationException(Provider.ErrorMessage);
+            if (!Provider.Read(this) && !string.IsNullOrWhiteSpace(Provider.ErrorMessage))
+                Trace.WriteLine("Westwind.Utilities.Configuration.AppConfiguration initialization error: " + Provider.ErrorMessage);
         }
 
         /// <summary>


### PR DESCRIPTION
We're using Westwind.Globalization.AspnetCore in our project and when deploying to our staging environment, the application would crash with an InvalidOperationException.
Using the NuGet packages alone we could not figure out the cause, so I got the sources, set a breakpoint and found it was trying to write a default configuration file (DbResourceConfiguration.json) which would be overridden by the appsettings.json any way.

This fix will send a message to Diagnostics.Trace (if there is any info to log) instead of throwing an exception.
Not 100% sure this is the best solution, maybe the exception should rather be caught by the Globalization lib, but I figured that most applications would not normally have full read-write access to their own location.