### PR TITLE
Do not break UNC paths

### DIFF
--- a/Westwind.Utilities/Utilities/FileUtils.cs
+++ b/Westwind.Utilities/Utilities/FileUtils.cs
@@ -210,7 +210,11 @@ namespace Westwind.Utilities
 
 	        char slash = Path.DirectorySeparatorChar;
 	        path = path.Replace('/', slash).Replace('\\', slash);
-	        return path.Replace(slash.ToString() + slash.ToString(), slash.ToString());
+            string doubleSlash = string.Concat(slash, slash);
+            if (path.StartsWith(doubleSlash))
+                return string.Concat(doubleSlash, path.TrimStart(slash).Replace(doubleSlash, slash.ToString()));
+            else
+                return path.Replace(doubleSlash, slash.ToString());
         }
 
 


### PR DESCRIPTION
Another bug we ran into when using shared configuration on a load-balanced cluster.

The UNC path got broken, "\\\\path" would become "\path".
This fix will remove double slashes except two at the start of the string (if they occur).

The same fix can be applied to some duplicate code in Westwind.Globalization\Utilities\DbResourceUtilitities.cs
