### PR TITLE
Reduce allocations in VersionUtils.cs

### DIFF
--- a/Westwind.Utilities/Utilities/VersionUtils.cs
+++ b/Westwind.Utilities/Utilities/VersionUtils.cs
@@ -28,21 +28,25 @@ namespace Westwind.Utilities
 
             var items = new int[] { version.Major, version.Minor, version.Build, version.Revision };
 
-            //items = items[0..maxTokens];
-            items = items.Take(maxTokens).ToArray();
-
-            var baseVersion = string.Empty;
-            for (int i = 0; i < minTokens; i++)
+            var length = maxTokens;
+            for (length = maxTokens; length > minTokens; length--)
             {
-                baseVersion += "." + items[i];
+                if (items[length - 1] != 0)
+                {
+                    break;
+                }
             }
 
-            var extendedVersion = string.Empty;
-            for (int i = minTokens; i < maxTokens; i++)
+            var builder = new StringBuilder(length * 11);
+
+            for (int i = 0; i < length; i++)
             {
-                extendedVersion += "." + items[i];
+                builder
+                    .Append(items[i])
+                    .Append(".");
             }
-            return baseVersion.TrimStart('.') + extendedVersion.TrimEnd('.', '0');
+
+            return builder.ToString(0, builder.Length - 1);
         }
 
 


### PR DESCRIPTION
The current implementation has unnecessary allocations.

1. Always builds a version string with `maxTokens`.
2. Allocates 2 strings per segment.
3. Uses LINQ.

This version trims the segments eliminating the `0`s at the end and uses a `StringBuilder` to build the version text.

For .NET 6.0 or above, this could allocate just the final `string`:

```csharp
public static string FormatVersion(this Version version, int minTokens = 2, int maxTokens = 2)
{
    if (minTokens < 1)
        minTokens = 1;
    if (minTokens > 4)
        minTokens = 4;
    if (maxTokens < minTokens)
        maxTokens = minTokens;
    if (maxTokens > 4)
        maxTokens = 4;

    ReadOnlySpan<int> items = stackalloc int[] { version.Major, version.Minor, version.Build, version.Revision };

    var length = maxTokens;
    for (length = maxTokens; length > minTokens; length--)
    {
        if (items[length - 1] != 0)
        {
            break;
        }
    }

    Span<char> buffer = stackalloc char[length * 11];
    var builder = buffer;

    for (int i = 0; i < length; i++)
    {
        items[i].TryFormat(builder, out var charsWritten);
        builder[charsWritten] = '.';
        builder = builder.Slice(charsWritten + 1);
    }
}
```


